### PR TITLE
Support resources available in specific regions

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -56,6 +56,10 @@ func scanRegion(ctx context.Context, cfg *Config, awsConfig aws.Config, region s
 
 	for _, service := range cfg.Services {
 		for _, resourceType := range service.ResourceTypes {
+			if resourceType.Regions != nil && !slices.Contains(resourceType.Regions, region) {
+				continue
+			}
+
 			name := fmt.Sprintf("AWS::%s::%s", service.Name, resourceType.Name)
 			input := cloudcontrol.ListResourcesInput{TypeName: &name}
 

--- a/aws/config.go
+++ b/aws/config.go
@@ -19,7 +19,8 @@ type ServiceConfig struct {
 }
 
 type ResourceTypeConfig struct {
-	Name string `yaml:"name"`
+	Name    string   `yaml:"name"`
+	Regions []string `yaml:"regions"`
 }
 
 func LoadConfig(filename string) (*Config, error) {

--- a/config-tests/src/config/config.kt
+++ b/config-tests/src/config/config.kt
@@ -35,6 +35,7 @@ data class Service(
 @Serializable
 data class ResourceType(
     val name: String,
+    val regions: List<String> = emptyList(),
 ) {
     companion object {
         val List<ResourceType>.names

--- a/config-tests/test/ResourceTypes.kt
+++ b/config-tests/test/ResourceTypes.kt
@@ -84,4 +84,65 @@ class ResourceTypes {
             }
         })
     }
+
+    @Test
+    fun `regions are sorted`() {
+        assertAll(config.services.flatMap { service ->
+            service.resourceTypes.map { rt ->
+                {
+                    assert(rt.regions == rt.regions.sorted()) {
+                        "${service.name}/${rt.name}"
+                    }
+                }
+            }
+        })
+    }
+
+    @Test
+    fun `regions are unique`() {
+        assertAll(config.services.flatMap { service ->
+            service.resourceTypes.map { rt ->
+                {
+                    val duplicates = findDuplicates(rt.regions)
+                    assert(duplicates.isEmpty()) { "${service.name}/${rt.name}: $duplicates" }
+                }
+            }
+        })
+    }
+
+    @Test
+    fun `missing regions`() {
+        assertAll(config.services.flatMap { service ->
+            service.resourceTypes.map { rt ->
+                {
+                    val configRegions = if (rt.regions.isEmpty()) config.regions else rt.regions
+                    val schemaRegions = schema
+                        .services.single { it.name == service.name }
+                        .resourceTypes.single { it.name == rt.name }
+                        .regions
+
+                    val diff = schemaRegions - configRegions
+                    assert(diff.isEmpty()) { "${service.name}/${rt.name}: $diff" }
+                }
+            }
+        })
+    }
+
+    @Test
+    fun `unknown regions`() {
+        assertAll(config.services.flatMap { service ->
+            service.resourceTypes.map { rt ->
+                {
+                    val configRegions = if (rt.regions.isEmpty()) config.regions else rt.regions
+                    val schemaRegions = schema
+                        .services.single { it.name == service.name }
+                        .resourceTypes.single { it.name == rt.name }
+                        .regions
+
+                    val diff = configRegions - schemaRegions
+                    assert(diff.isEmpty()) { "${service.name}/${rt.name}: $diff" }
+                }
+            }
+        })
+    }
 }

--- a/dritf.yaml
+++ b/dritf.yaml
@@ -36,26 +36,48 @@ regions:
 services:
   - name: ECR
     resource_types:
+      - name: PublicRepository
+        regions:
+          - us-east-1
       - name: PullThroughCacheRule
       - name: RegistryPolicy
       - name: ReplicationConfiguration
       - name: Repository
       - name: RepositoryCreationTemplate
-    ignored_types:
-      - PublicRepository # region
 
   - name: Lambda
     resource_types:
+      - name: CodeSigningConfig
+        regions:
+          - af-south-1
+          - ap-east-1
+          - ap-northeast-1
+          - ap-northeast-2
+          - ap-south-1
+          - ap-southeast-1
+          - ap-southeast-2
+          - ca-central-1
+          - eu-central-1
+          - eu-north-1
+          - eu-south-1
+          - eu-west-1
+          - eu-west-2
+          - eu-west-3
+          - me-south-1
+          - sa-east-1
+          - us-east-1
+          - us-east-2
+          - us-west-1
+          - us-west-2
       - name: EventSourceMapping
       - name: Function
     ignored_types:
       - Alias # FunctionName
-      - CodeSigningConfig # region
       - EventInvokeConfig # FunctionName
       - LayerVersion # layer name
       - LayerVersionPermission # LayerVersionArn
       - Permission # FunctionName
-      - ResourcePolicy # region
+      - ResourcePolicy # list
       - Url # TargetFunctionArn
       - Version # FunctionName
 


### PR DESCRIPTION
Some resource types are not available everywhere.
`regions` can be explicitly listed:
```
services:
  - name: Lambda
    resource_types:
      - name: CodeSigningConfig
        regions:
          - af-south-1
          - ap-east-1
...
```
